### PR TITLE
Fix swift_version in podspec.

### DIFF
--- a/TTCalendarPicker.podspec
+++ b/TTCalendarPicker.podspec
@@ -22,7 +22,7 @@ A lightweight, highly customizable, infinite scrolling calendar picker developed
 
   s.ios.deployment_target = '10.0'
 
-  s.swift_version    = '5'
+  s.swift_version    = '5.0'
 
   s.source_files = 'TTCalendarPicker/Classes/**/*'
   s.dependency 'SnapKit'


### PR DESCRIPTION
'5' isn't a valid value, and is causing an upgrade prompt in Xcode.
![Screen Shot 2020-04-15 at 12 14 06 PM](https://user-images.githubusercontent.com/48235/79326117-a1dd5f80-7f12-11ea-8c47-f7077bd734cc.png)
