### PR TITLE
Upped calendar height priority to avoid layout ambiguity.

### DIFF
--- a/TTCalendarPicker/Classes/CalendarPicker.swift
+++ b/TTCalendarPicker/Classes/CalendarPicker.swift
@@ -105,7 +105,8 @@ public class CalendarPicker: UIView {
         collectionView.snp.makeConstraints { make in
             make.top.left.right.equalToSuperview()
             make.bottom.lessThanOrEqualToSuperview()
-            heightConstraint = make.height.equalTo(0).priority(.high).constraint
+            //  Higher than defaultHigh priority to avoid ambiguity with compression/hugging priority of contents.
+            heightConstraint = make.height.equalTo(0).priority(ConstraintPriority(875.0)).constraint
         }
     }
 


### PR DESCRIPTION
Leaving the calendar height constraint at default height means it ends up the same as the priority for a large number of UI elements in UI composition.

The idea here is to avoid breaking this constraint but allow it in some cases (while relaying out mostly). Upping the priority to the midpoint between `.defaultHigh` and `.required` should do the trick nicely.

This is also required to avoid layout ambiguity when laying out the Thumbprint calendar picker.