### PR TITLE
Omoralesvivo/calendar height ambiguity

### DIFF
--- a/TTCalendarPicker.podspec
+++ b/TTCalendarPicker.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'TTCalendarPicker'
-  s.version          = '0.1.6'
+  s.version          = '0.1.7'
   s.summary          = 'A lightweight, customizable, infinite scrolling calendar in Swift'
   s.description      = <<-DESC
 A lightweight, highly customizable, infinite scrolling calendar picker developed by the iOS teams at Thumbtack, Inc.

--- a/TTCalendarPicker/Classes/CalendarPicker.swift
+++ b/TTCalendarPicker/Classes/CalendarPicker.swift
@@ -103,8 +103,7 @@ public class CalendarPicker: UIView {
         })
 
         collectionView.snp.makeConstraints { make in
-            make.top.left.right.equalToSuperview()
-            make.bottom.lessThanOrEqualToSuperview()
+            make.edges.equalToSuperview()
             //  Higher than defaultHigh priority to avoid ambiguity with compression/hugging priority of contents.
             heightConstraint = make.height.equalTo(0).priority(ConstraintPriority(875.0)).constraint
         }


### PR DESCRIPTION
With all the mess wrangling two different repositories I accidentally unwinded one of the changes made to TTCalendarPicker to avoid it having an ambiguous layout, which was causing verification failures in the man repo PR (as it should).

This has been already submitted as pod 0.1.7 and tested as working properly from the main repo. Still should be merged into master.